### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/ptools.rs
+++ b/src/ptools.rs
@@ -165,7 +165,7 @@ impl Error for ParseError {
 
 impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.description())
+        write!(f, "{}", self.reason)
     }
 }
 


### PR DESCRIPTION
```
warning: use of deprecated method `std::error::Error::description`: use the Display impl or to_string()
   --> src/ptools.rs:168:30
    |
168 |         write!(f, "{}", self.description())
    |                              ^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default
```