### PR TITLE
pfiles: print symbolic open flag names instead of debug format

### DIFF
--- a/src/bin/pfiles.rs
+++ b/src/bin/pfiles.rs
@@ -153,7 +153,7 @@ fn print_file_type(file_type: &FileType) -> String {
 }
 
 fn print_open_flags(flags: u64) {
-    let open_flags = vec![
+    let open_flags = [
         (OFlag::O_APPEND, "O_APPEND"),
         (OFlag::O_ASYNC, "O_ASYNC"),
         (OFlag::O_CLOEXEC, "O_CLOEXEC"),
@@ -186,9 +186,9 @@ fn print_open_flags(flags: u64) {
     // O_LARGEFILE == 0. Should that get printed everywhere?
     // probably yes, if we want to match illumos
 
-    for &(flag, _desc) in open_flags.iter() {
+    for &(flag, desc) in open_flags.iter() {
         if (flags as i32 & flag.bits()) != 0 {
-            print!("|{:?}", flag); // TODO don't use debug
+            print!("|{}", desc);
         }
     }
 

--- a/tests/pfiles_test.rs
+++ b/tests/pfiles_test.rs
@@ -101,8 +101,8 @@ fn pfiles_matrix_covers_file_types_and_socket_families() {
     assert_contains(&stdout, "O_RDONLY");
     assert_contains(&stdout, "O_WRONLY");
     assert_contains(&stdout, "O_RDWR");
-    assert_contains(&stdout, "OFlag(O_CLOEXEC)");
-    assert_contains(&stdout, "OFlag(O_NDELAY)");
+    assert_contains(&stdout, "O_CLOEXEC");
+    assert_contains(&stdout, "O_NONBLOCK");
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- The code used debug formatting (`{:?}`) on `OFlag` values when printing open flags, yielding unstable and less user-friendly output.
- The goal is to produce deterministic, human-readable flag names (e.g. `O_CLOEXEC`) to match expected pfiles output and tests.

### Description
- Updated `print_open_flags` in `src/bin/pfiles.rs` to use a table of `(OFlag, &str)` and print the `desc` string instead of debug-formatting the `OFlag` value.
- Converted the local `open_flags` from a `Vec` to an array and iterated with `for &(flag, desc) in open_flags.iter()` for clarity and stability.
- Adjusted test expectations in `tests/pfiles_test.rs` to assert `O_CLOEXEC` and `O_NONBLOCK` rather than their previous debug-style strings.

### Testing
- Built example binaries with `cargo build --examples` which completed successfully.
- Ran the pfiles integration tests with `cargo test --test pfiles_test` and all tests passed (`6 passed; 0 failed`).
- The updated `pfiles_matrix` example output was validated by the modified assertions in `tests/pfiles_test.rs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993b1d7733c8333973105ca80017419)