### PR TITLE
Add IPv6 socket parsing and end-to-end pfiles coverage

### DIFF
--- a/examples/pfiles_matrix.rs
+++ b/examples/pfiles_matrix.rs
@@ -65,7 +65,13 @@ fn main() {
     let _tcp_client = TcpStream::connect(tcp_addr).unwrap();
     let (_tcp_server_conn, _peer) = tcp_listener.accept().unwrap();
 
+    let tcp6_listener = TcpListener::bind("[::1]:0").unwrap();
+    let tcp6_addr = tcp6_listener.local_addr().unwrap();
+    let _tcp6_client = TcpStream::connect(tcp6_addr).unwrap();
+    let (_tcp6_server_conn, _peer6) = tcp6_listener.accept().unwrap();
+
     let _udp_socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let _udp6_socket = UdpSocket::bind("[::1]:0").unwrap();
 
     // Signal parent process (the test process) that this process is ready to be observed by the
     // ptool being tested.
@@ -83,6 +89,7 @@ fn main() {
         eventfd,
         unix_listener,
         tcp_listener,
+        tcp6_listener,
     );
 
     loop {


### PR DESCRIPTION
### Motivation
- Ensure `pfiles` can parse and display Linux IPv6 sockets from `/proc/[pid]/net/{tcp6,udp6,raw6}` so end-to-end tests cover AF_INET6 cases.
- Preserve the existing output contracts while adding IPv6 cases to the matrix tests.
- Correct wildcard peer semantics so unspecified addresses (IPv4 `0.0.0.0` and IPv6 `::`) are treated as “no concrete peer”.

### Description
- Implemented `parse_ipv6_sock_addr` and added `Ipv6Addr`/`IpAddr` handling to parse `/proc/.../tcp6|udp6|raw6` entries and produce `SocketAddr` values.
- Generalized the proc parsing function to accept a parser and `AddressFamily`, and wired in `tcp6`, `udp6`, and `raw6` using `parse_ipv6_sock_addr` while keeping IPv4 parsing unchanged.
- Added `concrete_peer_addr` to normalize unspecified peer addresses to `None` so listeners do not emit peer lines for wildcard peers.
- Stopped special-casing omission of peer printing in `print_sock_address` and rely on normalized `peer_addr` semantics to preserve output contract.
- Extended `examples/pfiles_matrix.rs` to create IPv6 TCP listener/peer and IPv6 UDP sockets so tests exercise real IPv6 descriptors.
- Extended `tests/pfiles_test.rs` matrix assertions to check AF_INET6 `sockname`/`peername` and datagram cases while keeping existing IPv4 expectations stable.
- Files changed: `src/bin/pfiles.rs`, `examples/pfiles_matrix.rs`, `tests/pfiles_test.rs`.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo build --examples` and `cargo test --test pfiles_test`; the updated test suite passed: `7 passed; 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993c68476588333aed2b573eb0366ae)