### PR TITLE
pfiles: fallback to sockprotoname xattr and stabilize tests/examples with env-driven readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ The integration tests in `tests/` execute ptools binaries via
 `tests/common::run_ptool`, so make sure the `target/debug/<tool>` binaries are
 instrumented (the `cargo build --bins` step above does that).
 
+`tests/pfiles_test::pfiles_resolves_socket_metadata_for_target_net_namespace` is an
+end-to-end regression check for socket resolution across network namespaces. It
+uses `unshare --net` to run an example process in a separate net namespace and
+verifies `pfiles` still resolves socket metadata via `/proc/<pid>/net/*`. In
+environments where unprivileged net namespace creation is blocked, the test
+self-skips and prints the reason.
+
 ## Why ptools?
 
 Linux already has a number of mechanisms which can be used to inspect the state

--- a/examples/args_env.rs
+++ b/examples/args_env.rs
@@ -1,11 +1,15 @@
+use std::env;
 use std::fs::File;
 use std::thread;
 use std::time::Duration;
 
 fn main() {
+    let signal_path =
+        env::var("PTOOLS_TEST_READY_FILE").unwrap_or_else(|_| "/tmp/ptools-test-ready".to_string());
+
     // Signal parent process (the test process) that this process is ready to be observed by the
     // ptool being tested.
-    File::create("/tmp/ptools-test-ready").unwrap();
+    File::create(signal_path).unwrap();
 
     // Wait for the parent to finish running the ptool and then kill us.
     loop {

--- a/examples/netlink.rs
+++ b/examples/netlink.rs
@@ -18,12 +18,16 @@ use nix::sys::socket::{
     bind, socket, AddressFamily, NetlinkAddr, SockFlag, SockProtocol, SockType,
 };
 
+use std::env;
 use std::fs::File;
 use std::os::fd::AsRawFd;
 use std::thread;
 use std::time::Duration;
 
 fn main() {
+    let signal_path =
+        env::var("PTOOLS_TEST_READY_FILE").unwrap_or_else(|_| "/tmp/ptools-test-ready".to_string());
+
     let fd = socket(
         AddressFamily::Netlink,
         SockType::Datagram,
@@ -36,7 +40,7 @@ fn main() {
 
     // Signal parent process (the test process) that this process is ready to be observed by the
     // ptool being tested.
-    File::create("/tmp/ptools-test-ready").unwrap();
+    File::create(signal_path).unwrap();
 
     // Wait for the parent to finish running the ptool and then kill us.
     loop {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::thread;
 use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 // Find an executable produced by the Cargo build
 pub fn find_exec(name: &str) -> PathBuf {
@@ -67,7 +68,12 @@ pub fn run_ptool_with_options_and_capture(
     test_proc_args: &[&str],
     test_proc_env: &[(&str, &str)],
 ) -> Output {
-    let signal_file = Path::new("/tmp/ptools-test-ready");
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_nanos();
+    let signal_path = format!("/tmp/ptools-test-ready-{}-{}", std::process::id(), unique);
+    let signal_file = Path::new(&signal_path);
     if let Err(e) = fs::remove_file(signal_file) {
         if e.kind() != io::ErrorKind::NotFound {
             panic!("Failed to remove {:?}: {:?}", signal_file, e.kind())
@@ -80,6 +86,7 @@ pub fn run_ptool_with_options_and_capture(
         .stdin(Stdio::null())
         .stderr(Stdio::inherit())
         .stdout(Stdio::inherit())
+        .env("PTOOLS_TEST_READY_FILE", &signal_path)
         .envs(test_proc_env.iter().copied());
 
     let mut examined_proc = examined_proc_cmd.spawn().unwrap();
@@ -100,6 +107,11 @@ pub fn run_ptool_with_options_and_capture(
         .unwrap();
 
     examined_proc.kill().unwrap();
+    if let Err(e) = fs::remove_file(signal_file) {
+        if e.kind() != io::ErrorKind::NotFound {
+            panic!("Failed to remove {:?}: {:?}", signal_file, e.kind())
+        }
+    }
 
     ptool_output
 }


### PR DESCRIPTION
### Motivation

- Improve `pfiles` robustness when socket family metadata is missing from procfs by falling back to the `system.sockprotoname` xattr for `/proc/<pid>/fd/<fd>`.
- Ensure socket metadata resolution is performed against the target process's network namespace so pfiles reports correct info for namespaced processes.
- Make the test harness and example helper processes deterministic and race-free by using a unique readiness file path configurable via environment variables.

### Description

- Add `get_sockprotoname(pid, fd)` to read the `system.sockprotoname` xattr and `handle_sockprotoname_xattr_error` to suppress expected xattr errors on Linux. 
- Use the xattr fallback in `print_file` when socket inode lookups in the target `/proc/<pid>/net/*` do not yield metadata. 
- Clarify that `fetch_sock_info` reads `/proc/<pid>/net/*` to resolve socket metadata in the target process's network namespace. 
- Make the test harness use a unique readiness file and export `PTOOLS_TEST_READY_FILE` from `run_ptool*` helpers, and update `examples/*` and `examples/pfiles_matrix` to honor `PTOOLS_TEST_READY_FILE` and `PTOOLS_MATRIX_PREFIX` so tests do not collide. 
- Add two tests: `pfiles_resolves_socket_metadata_for_target_net_namespace` (netns end-to-end regression that self-skips when unshare is unavailable) and `pfiles_falls_back_to_sockprotoname_xattr_for_unknown_socket_family` (AF_ALG xattr fallback); update existing matrix test to use unique paths and normalize assertions.
- Update `README.md` with a note about the netns e2e test behavior.

### Testing

- Ran `cargo test --test pfiles_test pfiles_falls_back_to_sockprotoname_xattr_for_unknown_socket_family -- --exact`, and the test passed (`ok`).
- The added net-namespace end-to-end test is designed to self-skip in environments without `unshare` or unprivileged netns support.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993c99a8a7883338924d76221eae4dc)