### PR TITLE
auxv: Dereference string pointers (AT_EXECFN, AT_PLATFORM)

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -28,7 +28,7 @@
 
 use std::borrow::Cow;
 
-use nix::unistd::{Gid, Group, Uid, User};
+use nix::unistd::{sysconf, Gid, Group, SysconfVar, Uid, User};
 
 use crate::proc::auxv::{decode_hwcap, AuxvType};
 use crate::proc::{Error, ProcHandle};
@@ -94,25 +94,35 @@ pub fn print_env_from(handle: &ProcHandle) -> Result<(), Error> {
 pub fn print_auxv_from(handle: &ProcHandle) -> Result<(), Error> {
     let auxv = handle.auxv()?;
     let hex_width = auxv.word_size * 2;
+    let page_size = auxv
+        .entries
+        .iter()
+        .find(|e| e.key == AuxvType::PageSz)
+        .map(|e| e.value)
+        .or_else(|| {
+            sysconf(SysconfVar::PAGE_SIZE)
+                .ok()
+                .flatten()
+                .map(|v| v as u64)
+        })
+        .unwrap_or(4096);
 
     print_proc_summary_from(handle);
     for entry in &auxv.entries {
-        if entry.key == AuxvType::ExecFn {
-            let s = handle
-                .exe()
-                .ok()
-                .and_then(|p| p.to_str().map(str::to_string))
-                .unwrap_or_default();
-            let key = auxv_type_str(&entry.key);
-            println!(
-                "{:<15} 0x{:0width$x} {}",
-                key,
-                entry.value,
-                s,
-                width = hex_width
-            );
+        let key = auxv_type_str(&entry.key);
+        if entry.key.is_string_pointer() {
+            if let Some(s) = handle.read_cstring_at(entry.value, page_size) {
+                println!(
+                    "{:<15} 0x{:0width$x} {}",
+                    key,
+                    entry.value,
+                    s,
+                    width = hex_width
+                );
+            } else {
+                println!("{:<15} 0x{:0width$x}", key, entry.value, width = hex_width);
+            }
         } else if let Some(flags) = decode_hwcap(entry.key, entry.value) {
-            let key = auxv_type_str(&entry.key);
             println!(
                 "{:<15} 0x{:0width$x} {}",
                 key,
@@ -121,7 +131,6 @@ pub fn print_auxv_from(handle: &ProcHandle) -> Result<(), Error> {
                 width = hex_width
             );
         } else if entry.key.is_uid() {
-            let key = auxv_type_str(&entry.key);
             if let Some(name) = User::from_uid(Uid::from_raw(entry.value as u32))
                 .ok()
                 .flatten()
@@ -139,7 +148,6 @@ pub fn print_auxv_from(handle: &ProcHandle) -> Result<(), Error> {
                 println!("{:<15} 0x{:0width$x}", key, entry.value, width = hex_width);
             }
         } else if entry.key.is_gid() {
-            let key = auxv_type_str(&entry.key);
             if let Some(name) = Group::from_gid(Gid::from_raw(entry.value as u32))
                 .ok()
                 .flatten()
@@ -157,7 +165,6 @@ pub fn print_auxv_from(handle: &ProcHandle) -> Result<(), Error> {
                 println!("{:<15} 0x{:0width$x}", key, entry.value, width = hex_width);
             }
         } else {
-            let key = auxv_type_str(&entry.key);
             println!("{:<15} 0x{:0width$x}", key, entry.value, width = hex_width);
         }
     }

--- a/src/proc/auxv.rs
+++ b/src/proc/auxv.rs
@@ -105,6 +105,10 @@ impl AuxvType {
     pub fn is_gid(self) -> bool {
         matches!(self, Self::Gid | Self::Egid)
     }
+
+    pub fn is_string_pointer(self) -> bool {
+        matches!(self, Self::ExecFn | Self::Platform | Self::BasePlatform)
+    }
 }
 
 /// A single entry from the auxiliary vector.

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -213,9 +213,26 @@ impl ProcHandle {
 
     /// Read memory from the process — core dump PT_LOAD segments or live
     /// `process_vm_readv(2)`.
-    #[allow(dead_code)]
     pub(crate) fn read_memory(&self, addr: u64, buf: &mut [u8]) -> bool {
         self.source.read_memory(addr, buf)
+    }
+
+    /// Read a NUL-terminated C string from the target process's memory.
+    ///
+    /// Best-effort: reads from `addr` to the end of its page. If no NUL
+    /// terminator is found within that range, returns the partial content.
+    pub(crate) fn read_cstring_at(&self, addr: u64, page_size: u64) -> Option<String> {
+        if addr == 0 {
+            return None;
+        }
+        let page_size = page_size.clamp(1, 64 * 1024);
+        let bytes_to_page_end = (page_size - (addr % page_size)) as usize;
+        let mut buf = vec![0u8; bytes_to_page_end];
+        if !self.read_memory(addr, &mut buf) {
+            return None;
+        }
+        let len = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+        Some(String::from_utf8_lossy(&buf[..len]).into_owned())
     }
 
     // -- Pure delegation ---------------------------------------------

--- a/src/source/elf.rs
+++ b/src/source/elf.rs
@@ -122,7 +122,6 @@ impl CoreElf {
     }
 
     /// Read memory from the core file's PT_LOAD segments.
-    #[allow(dead_code)]
     pub(super) fn read_memory(&self, addr: u64, buf: &mut [u8]) -> bool {
         unsafe {
             let mut phnum: libc::size_t = 0;

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -73,7 +73,6 @@ pub(crate) trait ProcSource {
     fn read_net_file(&self, name: &str) -> io::Result<String>;
 
     // Memory
-    #[allow(dead_code)]
     fn read_memory(&self, addr: u64, buf: &mut [u8]) -> bool;
 
     /// Walk and symbolize frames for one thread.  Manages dwfl internally.

--- a/tests/pargs_penv_test.rs
+++ b/tests/pargs_penv_test.rs
@@ -229,6 +229,38 @@ fn pauxv_prints_auxv_entries() {
         pagesz,
         allowed_page_sizes
     );
+
+    // AT_EXECFN should show the dereferenced string (an absolute path) when
+    // process_vm_readv is permitted.  On Ubuntu (yama ptrace_scope=1) the tool
+    // process is a sibling, not a parent, of the target so the read is denied
+    // and only the hex address is printed.
+    let execfn_line = stdout
+        .lines()
+        .find(|line| line.starts_with("AT_EXECFN"))
+        .unwrap_or_else(|| panic!("Expected AT_EXECFN in pauxv output:\n\n{}\n\n", stdout));
+    let execfn_tokens: Vec<&str> = execfn_line.split_whitespace().collect();
+    if execfn_tokens.len() >= 3 {
+        assert!(
+            execfn_tokens[2].starts_with('/'),
+            "AT_EXECFN string should be an absolute path, got '{}' in '{}'",
+            execfn_tokens[2],
+            execfn_line
+        );
+    }
+
+    // AT_PLATFORM: same caveat — only validate the string when present.
+    let platform_line = stdout.lines().find(|line| line.starts_with("AT_PLATFORM "));
+    if let Some(platform_line) = platform_line {
+        let platform_tokens: Vec<&str> = platform_line.split_whitespace().collect();
+        if platform_tokens.len() >= 3 {
+            assert!(
+                !platform_tokens[2].starts_with("0x"),
+                "AT_PLATFORM string should not be a hex address, got '{}' in '{}'",
+                platform_tokens[2],
+                platform_line
+            );
+        }
+    }
 }
 
 #[test]
@@ -323,4 +355,36 @@ fn pargs_x_prints_auxv_entries() {
         pagesz,
         allowed_page_sizes
     );
+
+    // AT_EXECFN should show the dereferenced string (an absolute path) when
+    // process_vm_readv is permitted.  On Ubuntu (yama ptrace_scope=1) the tool
+    // process is a sibling, not a parent, of the target so the read is denied
+    // and only the hex address is printed.
+    let execfn_line = stdout
+        .lines()
+        .find(|line| line.starts_with("AT_EXECFN"))
+        .unwrap_or_else(|| panic!("Expected AT_EXECFN in pargs -x output:\n\n{}\n\n", stdout));
+    let execfn_tokens: Vec<&str> = execfn_line.split_whitespace().collect();
+    if execfn_tokens.len() >= 3 {
+        assert!(
+            execfn_tokens[2].starts_with('/'),
+            "AT_EXECFN string should be an absolute path, got '{}' in '{}'",
+            execfn_tokens[2],
+            execfn_line
+        );
+    }
+
+    // AT_PLATFORM: same caveat — only validate the string when present.
+    let platform_line = stdout.lines().find(|line| line.starts_with("AT_PLATFORM "));
+    if let Some(platform_line) = platform_line {
+        let platform_tokens: Vec<&str> = platform_line.split_whitespace().collect();
+        if platform_tokens.len() >= 3 {
+            assert!(
+                !platform_tokens[2].starts_with("0x"),
+                "AT_PLATFORM string should not be a hex address, got '{}' in '{}'",
+                platform_tokens[2],
+                platform_line
+            );
+        }
+    }
 }


### PR DESCRIPTION
Read the actual C strings from process memory for auxv entries that are string pointers, instead of showing only the hex address.

Fixes #70