### PR TITLE
feat: Parse ELF core notes as fallback for coredump data sources

### DIFF
--- a/src/model/auxv.rs
+++ b/src/model/auxv.rs
@@ -30,6 +30,29 @@ pub enum ByteOrder {
     Big,
 }
 
+impl ByteOrder {
+    pub fn u16(self, bytes: [u8; 2]) -> u16 {
+        match self {
+            ByteOrder::Little => u16::from_le_bytes(bytes),
+            ByteOrder::Big => u16::from_be_bytes(bytes),
+        }
+    }
+
+    pub fn u32(self, bytes: [u8; 4]) -> u32 {
+        match self {
+            ByteOrder::Little => u32::from_le_bytes(bytes),
+            ByteOrder::Big => u32::from_be_bytes(bytes),
+        }
+    }
+
+    pub fn u64(self, bytes: [u8; 8]) -> u64 {
+        match self {
+            ByteOrder::Little => u64::from_le_bytes(bytes),
+            ByteOrder::Big => u64::from_be_bytes(bytes),
+        }
+    }
+}
+
 /// An auxiliary vector entry type (`AT_*` constant).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuxvType {
@@ -132,18 +155,12 @@ impl Auxv {
                 4 => {
                     let mut buf = [0u8; 4];
                     reader.read_exact(&mut buf)?;
-                    Ok(match byte_order {
-                        ByteOrder::Little => u32::from_le_bytes(buf) as u64,
-                        ByteOrder::Big => u32::from_be_bytes(buf) as u64,
-                    })
+                    Ok(byte_order.u32(buf) as u64)
                 }
                 8 => {
                     let mut buf = [0u8; 8];
                     reader.read_exact(&mut buf)?;
-                    Ok(match byte_order {
-                        ByteOrder::Little => u64::from_le_bytes(buf),
-                        ByteOrder::Big => u64::from_be_bytes(buf),
-                    })
+                    Ok(byte_order.u64(buf))
                 }
                 _ => Err(io::Error::new(
                     io::ErrorKind::InvalidData,

--- a/src/model/status.rs
+++ b/src/model/status.rs
@@ -44,6 +44,25 @@ pub struct Status {
     pub cpus_allowed: Option<BTreeSet<usize>>,
 }
 
+/// Build a `BTreeSet<usize>` of 1-indexed signal numbers from an iterator of
+/// nibbles (4-bit values) ordered from least-significant to most-significant.
+fn nibbles_to_signal_set(nibbles: impl Iterator<Item = u8>) -> BTreeSet<usize> {
+    let mut set = BTreeSet::new();
+    for (nibble_idx, nibble) in nibbles.enumerate() {
+        for bit in 0..4u8 {
+            if (nibble & (1 << bit)) != 0 {
+                set.insert(nibble_idx * 4 + bit as usize + 1);
+            }
+        }
+    }
+    set
+}
+
+/// Convert a raw u64 bitmask to a `BTreeSet<usize>` of 1-indexed signal numbers.
+pub fn signal_bitmask_to_set(val: u64) -> BTreeSet<usize> {
+    nibbles_to_signal_set((0..16).map(|i| ((val >> (i * 4)) & 0xf) as u8))
+}
+
 /// Parse a hex signal mask (e.g. from `SigIgn`) into a set of 1-indexed signal numbers.
 pub fn parse_signal_mask(s: &str) -> io::Result<BTreeSet<usize>> {
     let trimmed = s.trim();
@@ -53,33 +72,23 @@ pub fn parse_signal_mask(s: &str) -> io::Result<BTreeSet<usize>> {
             "empty signal mask",
         ));
     }
-
-    let mut set = BTreeSet::new();
-    for (nibble_idx, ch) in trimmed.bytes().rev().enumerate() {
-        let nibble = match ch {
-            b'0'..=b'9' => ch - b'0',
-            b'a'..=b'f' => ch - b'a' + 10,
-            b'A'..=b'F' => ch - b'A' + 10,
-            _ => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "invalid hex character '{}' in mask '{}'",
-                        ch as char, trimmed
-                    ),
-                ));
-            }
-        };
-
-        for bit in 0..4 {
-            if (nibble & (1 << bit)) != 0 {
-                let sig = nibble_idx * 4 + bit as usize + 1;
-                set.insert(sig);
-            }
-        }
-    }
-
-    Ok(set)
+    let nibbles: Vec<u8> = trimmed
+        .bytes()
+        .rev()
+        .map(|ch| match ch {
+            b'0'..=b'9' => Ok(ch - b'0'),
+            b'a'..=b'f' => Ok(ch - b'a' + 10),
+            b'A'..=b'F' => Ok(ch - b'A' + 10),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "invalid hex character '{}' in mask '{}'",
+                    ch as char, trimmed
+                ),
+            )),
+        })
+        .collect::<io::Result<_>>()?;
+    Ok(nibbles_to_signal_set(nibbles.into_iter()))
 }
 
 /// Parse a kernel list-format string like `"0-3,5,7-8"` into a `BTreeSet<usize>`.

--- a/src/source/coredump.rs
+++ b/src/source/coredump.rs
@@ -27,9 +27,13 @@ use nix::libc;
 
 use super::dw::CoreDwfl;
 use super::elf::CoreElf;
+use super::elf::Prpsinfo;
+use super::elf::Prstatus;
 use super::ProcSource;
+use crate::model;
+use crate::model::auxv::ByteOrder;
+use crate::model::status::signal_bitmask_to_set;
 use crate::model::FromBufRead;
-use crate::model::{self};
 
 // ---------------------------------------------------------------------------
 // libsystemd journal FFI (minimal subset)
@@ -117,11 +121,14 @@ impl Drop for Journal {
 /// auxv, open fds, limits, proc status) are filled in from the systemd
 /// journal entry matching the coredump.
 pub(super) struct CoredumpSource {
+    fields: HashMap<String, Vec<u8>>,
     core_dwfl: OnceCell<Option<CoreDwfl>>,
     core_elf: Option<Arc<CoreElf>>,
     pid: OnceCell<u64>,
     tids: OnceCell<Vec<u64>>,
-    fields: HashMap<String, Vec<u8>>,
+    prpsinfo: OnceCell<Option<Prpsinfo>>,
+    auxv_bytes: OnceCell<Option<Vec<u8>>>,
+    prstatus_map: OnceCell<HashMap<u64, Prstatus>>,
 }
 
 /// A parsed entry from `COREDUMP_OPEN_FDS`.
@@ -195,11 +202,14 @@ impl CoredumpSource {
         }
 
         Ok(CoredumpSource {
+            fields,
             core_dwfl: OnceCell::new(),
             core_elf: core_elf.map(Arc::clone),
             pid: OnceCell::new(),
             tids: OnceCell::new(),
-            fields,
+            prpsinfo: OnceCell::new(),
+            auxv_bytes: OnceCell::new(),
+            prstatus_map: OnceCell::new(),
         })
     }
 
@@ -257,6 +267,70 @@ impl CoredumpSource {
             )
         })
     }
+
+    /// Lazily parse and cache all ELF notes (prstatus, prpsinfo, auxv).
+    fn ensure_notes(&self) {
+        self.prstatus_map
+            .get_or_init(|| match self.core_elf.as_ref() {
+                Some(elf) => {
+                    let (map, prpsinfo, auxv) = elf.parse_notes();
+                    let _ = self.prpsinfo.set(prpsinfo);
+                    let _ = self.auxv_bytes.set(auxv);
+                    map
+                }
+                None => {
+                    let _ = self.prpsinfo.set(None);
+                    let _ = self.auxv_bytes.set(None);
+                    HashMap::new()
+                }
+            });
+    }
+}
+
+/// Convert a timeval (sec, usec) to approximate clock ticks.
+fn timeval_to_ticks(sec: u64, usec: u64) -> u64 {
+    // sysconf(_SC_CLK_TCK) is typically 100 on Linux.
+    let hz = unsafe { nix::libc::sysconf(nix::libc::_SC_CLK_TCK) };
+    let hz = if hz > 0 { hz as u64 } else { 100 };
+    sec.saturating_mul(hz)
+        .saturating_add(usec.saturating_mul(hz) / 1_000_000)
+}
+
+/// Build a [`model::stat::Stat`] from prpsinfo and/or prstatus notes.
+fn prstatus_to_stat(prpsinfo: Option<&Prpsinfo>, prstatus: Option<&Prstatus>) -> model::stat::Stat {
+    model::stat::Stat {
+        state: prpsinfo.map(|p| model::stat::ProcState::from(p.pr_sname)),
+        ppid: prstatus
+            .map(|p| p.pr_ppid as u64)
+            .or_else(|| prpsinfo.map(|p| p.pr_ppid as u64)),
+        pgrp: prstatus
+            .map(|p| p.pr_pgrp as u64)
+            .or_else(|| prpsinfo.map(|p| p.pr_pgrp as u64)),
+        sid: prstatus
+            .map(|p| p.pr_sid as u64)
+            .or_else(|| prpsinfo.map(|p| p.pr_sid as u64)),
+        utime: prstatus.map(|p| timeval_to_ticks(p.pr_utime_sec, p.pr_utime_usec)),
+        stime: prstatus.map(|p| timeval_to_ticks(p.pr_stime_sec, p.pr_stime_usec)),
+        nice: prpsinfo.map(|p| p.pr_nice as i32),
+        ..model::stat::Stat::default()
+    }
+}
+
+/// Build a [`model::status::Status`] from prpsinfo and/or prstatus notes.
+fn prstatus_to_status(
+    prpsinfo: Option<&Prpsinfo>,
+    prstatus: Option<&Prstatus>,
+) -> model::status::Status {
+    model::status::Status {
+        ppid: prstatus
+            .map(|p| p.pr_ppid as u64)
+            .or_else(|| prpsinfo.map(|p| p.pr_ppid as u64)),
+        ruid: prpsinfo.map(|p| p.pr_uid),
+        rgid: prpsinfo.map(|p| p.pr_gid),
+        sig_blk: prstatus.map(|p| signal_bitmask_to_set(p.pr_sighold)),
+        sig_pnd: prstatus.map(|p| signal_bitmask_to_set(p.pr_sigpend)),
+        ..model::status::Status::default()
+    }
 }
 
 fn unsupported(what: &str) -> io::Error {
@@ -285,32 +359,117 @@ impl ProcSource for CoredumpSource {
     }
 
     fn word_size(&self) -> usize {
-        std::mem::size_of::<usize>()
+        self.core_elf
+            .as_ref()
+            .and_then(|elf| elf.word_size())
+            .unwrap_or(std::mem::size_of::<usize>())
     }
 
-    fn byte_order(&self) -> model::auxv::ByteOrder {
-        if cfg!(target_endian = "big") {
-            model::auxv::ByteOrder::Big
-        } else {
-            model::auxv::ByteOrder::Little
-        }
+    fn byte_order(&self) -> ByteOrder {
+        self.core_elf
+            .as_ref()
+            .and_then(|elf| elf.byte_order())
+            .unwrap_or(if cfg!(target_endian = "big") {
+                ByteOrder::Big
+            } else {
+                ByteOrder::Little
+            })
     }
 
     fn read_stat(&self) -> io::Result<model::stat::Stat> {
-        Err(unsupported("stat"))
+        let pid = self.pid();
+        self.ensure_notes();
+        let prpsinfo = self
+            .prpsinfo
+            .get()
+            .expect("ensure_notes initialized")
+            .as_ref();
+        let prstatus = self
+            .prstatus_map
+            .get()
+            .expect("ensure_notes initialized")
+            .get(&pid);
+        if prstatus.is_some() || prpsinfo.is_some() {
+            return Ok(prstatus_to_stat(prpsinfo, prstatus));
+        }
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "stat not available from coredump",
+        ))
     }
 
     fn read_status(&self) -> io::Result<model::status::Status> {
-        let text = self.get_field_str("COREDUMP_PROC_STATUS")?;
-        model::status::Status::from_buf_read(text.as_bytes())
+        // Prefer the journal's COREDUMP_PROC_STATUS (full /proc/pid/status snapshot).
+        if let Ok(text) = self.get_field_str("COREDUMP_PROC_STATUS") {
+            return model::status::Status::from_buf_read(text.as_bytes());
+        }
+        // Fall back to prstatus/prpsinfo notes for the main thread.
+        let pid = self.pid();
+        self.ensure_notes();
+        let prpsinfo = self
+            .prpsinfo
+            .get()
+            .expect("ensure_notes initialized")
+            .as_ref();
+        let prstatus = self
+            .prstatus_map
+            .get()
+            .expect("ensure_notes initialized")
+            .get(&pid);
+        if prstatus.is_some() || prpsinfo.is_some() {
+            return Ok(prstatus_to_status(prpsinfo, prstatus));
+        }
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "status not available from coredump",
+        ))
     }
 
     fn read_comm(&self) -> io::Result<String> {
-        self.get_field_str("COREDUMP_COMM").map(str::to_string)
+        if let Ok(s) = self.get_field_str("COREDUMP_COMM") {
+            return Ok(s.to_string());
+        }
+        self.ensure_notes();
+        if let Some(prpsinfo) = self
+            .prpsinfo
+            .get()
+            .expect("ensure_notes initialized")
+            .as_ref()
+        {
+            return Ok(prpsinfo.pr_fname.clone());
+        }
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "comm not available from coredump",
+        ))
     }
 
     fn read_cmdline(&self) -> io::Result<Vec<u8>> {
-        self.get_field("COREDUMP_CMDLINE").map(|b| b.to_vec())
+        if let Ok(b) = self.get_field("COREDUMP_CMDLINE") {
+            return Ok(b.to_vec());
+        }
+        // Fall back to prpsinfo pr_psargs as a single opaque argument.
+        // pr_psargs is a space-joined, truncated kernel rendering of the
+        // command line -- we cannot recover original argv boundaries from it,
+        // so return it whole rather than fabricating entries by splitting on
+        // spaces.
+        self.ensure_notes();
+        if let Some(prpsinfo) = self
+            .prpsinfo
+            .get()
+            .expect("ensure_notes initialized")
+            .as_ref()
+        {
+            if !prpsinfo.pr_psargs.is_empty() {
+                let mut bytes = prpsinfo.pr_psargs.as_bytes().to_vec();
+                bytes.push(0);
+                return Ok(bytes);
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "cmdline not available from coredump",
+        ))
     }
 
     fn read_environ(&self) -> io::Result<Vec<u8>> {
@@ -318,7 +477,24 @@ impl ProcSource for CoredumpSource {
     }
 
     fn read_auxv(&self) -> io::Result<model::auxv::Auxv> {
-        let bytes = self.get_field("COREDUMP_PROC_AUXV")?;
+        // Try the journal field first, then fall back to the ELF NT_AUXV note.
+        let bytes = match self.get_field("COREDUMP_PROC_AUXV") {
+            Ok(b) => b,
+            Err(_) => {
+                // Trigger note parsing so auxv_bytes gets populated.
+                self.ensure_notes();
+                match self.auxv_bytes.get().and_then(|o| o.as_deref()) {
+                    Some(b) => b,
+                    None => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Unsupported,
+                            "auxv data not found in coredump",
+                        ))
+                    }
+                }
+            }
+        };
+
         model::auxv::Auxv::from_read(bytes, self.word_size(), self.byte_order())
     }
 
@@ -356,8 +532,21 @@ impl ProcSource for CoredumpSource {
     }
 
     fn read_tid_stat(&self, tid: u64) -> io::Result<model::stat::Stat> {
-        if tid == self.pid() {
-            self.read_stat()
+        self.ensure_notes();
+        let prpsinfo = self
+            .prpsinfo
+            .get()
+            .expect("ensure_notes initialized")
+            .as_ref();
+        let prstatus = self
+            .prstatus_map
+            .get()
+            .expect("ensure_notes initialized")
+            .get(&tid);
+        if prstatus.is_some() {
+            Ok(prstatus_to_stat(prpsinfo, prstatus))
+        } else if tid == self.pid() && prpsinfo.is_some() {
+            Ok(prstatus_to_stat(prpsinfo, None))
         } else {
             Err(io::Error::new(
                 io::ErrorKind::NotFound,
@@ -367,8 +556,28 @@ impl ProcSource for CoredumpSource {
     }
 
     fn read_tid_status(&self, tid: u64) -> io::Result<model::status::Status> {
+        // Main thread: prefer journal string, fall back to prstatus.
         if tid == self.pid() {
-            self.read_status()
+            if let Ok(text) = self.get_field_str("COREDUMP_PROC_STATUS") {
+                return model::status::Status::from_buf_read(text.as_bytes());
+            }
+        }
+        // Any thread: fall back to prstatus/prpsinfo notes.
+        self.ensure_notes();
+        let prpsinfo = self
+            .prpsinfo
+            .get()
+            .expect("ensure_notes initialized")
+            .as_ref();
+        let prstatus = self
+            .prstatus_map
+            .get()
+            .expect("ensure_notes initialized")
+            .get(&tid);
+        if prstatus.is_some() {
+            Ok(prstatus_to_status(prpsinfo, prstatus))
+        } else if tid == self.pid() && prpsinfo.is_some() {
+            Ok(prstatus_to_status(prpsinfo, None))
         } else {
             Err(io::Error::new(
                 io::ErrorKind::NotFound,

--- a/src/source/elf.rs
+++ b/src/source/elf.rs
@@ -19,6 +19,8 @@
 //! Owns the ELF handle and (optionally decompressed) file descriptor for a
 //! core dump.  Provides memory reading via PT_LOAD segments.
 
+use crate::model::auxv::ByteOrder;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::io::Seek;
@@ -194,6 +196,372 @@ impl CoreElf {
             }
         }
         false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NT_PRSTATUS parsing
+// ---------------------------------------------------------------------------
+
+/// Parsed ELF64 NT_PRSTATUS note.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub(super) struct Prstatus {
+    pub pr_cursig: u16,
+    pub pr_sigpend: u64,
+    pub pr_sighold: u64,
+    pub pr_pid: u32,
+    pub pr_ppid: u32,
+    pub pr_pgrp: u32,
+    pub pr_sid: u32,
+    pub pr_utime_sec: u64,
+    pub pr_utime_usec: u64,
+    pub pr_stime_sec: u64,
+    pub pr_stime_usec: u64,
+    pub pr_reg: Vec<u8>,
+}
+
+/// Parsed ELF64 NT_PRPSINFO note.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub(super) struct Prpsinfo {
+    pub pr_sname: char,
+    pub pr_nice: i8,
+    pub pr_uid: u32,
+    pub pr_gid: u32,
+    pub pr_pid: u32,
+    pub pr_ppid: u32,
+    pub pr_pgrp: u32,
+    pub pr_sid: u32,
+    pub pr_fname: String,
+    pub pr_psargs: String,
+}
+
+/// ELF64 prstatus layout offsets (from <sys/procfs.h> / <linux/elfcore.h>):
+///
+/// ```text
+///  0: si_signo  (i32)
+///  4: si_code   (i32)
+///  8: si_errno  (i32)
+/// 12: pr_cursig (u16)
+/// 14: (2 bytes padding)
+/// 16: pr_sigpend (u64)
+/// 24: pr_sighold (u64)
+/// 32: pr_pid     (u32)
+/// 36: pr_ppid    (u32)
+/// 40: pr_pgrp    (u32)
+/// 44: pr_sid     (u32)
+/// 48: pr_utime   (timeval: u64 sec + u64 usec)
+/// 64: pr_stime   (timeval: u64 sec + u64 usec)
+/// 80: pr_cutime  (timeval)
+/// 96: pr_cstime  (timeval)
+/// ```
+fn parse_prstatus64(desc: &[u8], endian: ByteOrder) -> Option<Prstatus> {
+    if desc.len() < 112 {
+        return None;
+    }
+    let rd16 = |off: usize| endian.u16(desc[off..][..2].try_into().unwrap());
+    let rd32 = |off: usize| endian.u32(desc[off..][..4].try_into().unwrap());
+    let rd64 = |off: usize| endian.u64(desc[off..][..8].try_into().unwrap());
+
+    Some(Prstatus {
+        pr_cursig: rd16(12),
+        pr_sigpend: rd64(16),
+        pr_sighold: rd64(24),
+        pr_pid: rd32(32),
+        pr_ppid: rd32(36),
+        pr_pgrp: rd32(40),
+        pr_sid: rd32(44),
+        pr_utime_sec: rd64(48),
+        pr_utime_usec: rd64(56),
+        pr_stime_sec: rd64(64),
+        pr_stime_usec: rd64(72),
+        pr_reg: desc[112..].to_vec(),
+    })
+}
+
+/// ELF32 prstatus layout offsets (from <sys/procfs.h> / <linux/elfcore.h>):
+///
+/// ```text
+///  0: si_signo   (i32)
+///  4: si_code    (i32)
+///  8: si_errno   (i32)
+/// 12: pr_cursig  (u16)
+/// 14: (2 bytes padding)
+/// 16: pr_sigpend (u32)
+/// 20: pr_sighold (u32)
+/// 24: pr_pid     (i32)
+/// 28: pr_ppid    (i32)
+/// 32: pr_pgrp    (i32)
+/// 36: pr_sid     (i32)
+/// 40: pr_utime   (timeval: i32 sec + i32 usec)
+/// 48: pr_stime   (timeval: i32 sec + i32 usec)
+/// 56: pr_cutime  (timeval)
+/// 64: pr_cstime  (timeval)
+/// 72: pr_reg
+/// ```
+fn parse_prstatus32(desc: &[u8], endian: ByteOrder) -> Option<Prstatus> {
+    if desc.len() < 72 {
+        return None;
+    }
+    let rd16 = |off: usize| endian.u16(desc[off..][..2].try_into().unwrap());
+    let rd32 = |off: usize| endian.u32(desc[off..][..4].try_into().unwrap());
+
+    Some(Prstatus {
+        pr_cursig: rd16(12),
+        pr_sigpend: rd32(16) as u64,
+        pr_sighold: rd32(20) as u64,
+        pr_pid: rd32(24),
+        pr_ppid: rd32(28),
+        pr_pgrp: rd32(32),
+        pr_sid: rd32(36),
+        pr_utime_sec: rd32(40) as u64,
+        pr_utime_usec: rd32(44) as u64,
+        pr_stime_sec: rd32(48) as u64,
+        pr_stime_usec: rd32(52) as u64,
+        pr_reg: desc[72..].to_vec(),
+    })
+}
+
+/// ELF64 prpsinfo layout offsets (from <sys/procfs.h>):
+///
+/// ```text
+///  0: pr_state   (i8)
+///  1: pr_sname   (char)
+///  2: pr_zomb    (i8)
+///  3: pr_nice    (i8)
+///  4: (4 bytes padding)
+///  8: pr_flag    (u64)
+/// 16: pr_uid     (u32)
+/// 20: pr_gid     (u32)
+/// 24: pr_pid     (i32)
+/// 28: pr_ppid    (i32)
+/// 32: pr_pgrp    (i32)
+/// 36: pr_sid     (i32)
+/// 40: pr_fname   ([u8; 16])
+/// 56: pr_psargs  ([u8; 80])
+/// Total: 136 bytes
+/// ```
+fn parse_prpsinfo64(desc: &[u8], endian: ByteOrder) -> Option<Prpsinfo> {
+    if desc.len() < 136 {
+        return None;
+    }
+    let rd32 = |off: usize| endian.u32(desc[off..][..4].try_into().unwrap());
+
+    let nul_trimmed = |start: usize, len: usize| -> String {
+        let slice = &desc[start..start + len];
+        let end = slice.iter().position(|&b| b == 0).unwrap_or(len);
+        String::from_utf8_lossy(&slice[..end]).into_owned()
+    };
+
+    Some(Prpsinfo {
+        pr_sname: desc[1] as char,
+        pr_nice: desc[3] as i8,
+        pr_uid: rd32(16),
+        pr_gid: rd32(20),
+        pr_pid: rd32(24),
+        pr_ppid: rd32(28),
+        pr_pgrp: rd32(32),
+        pr_sid: rd32(36),
+        pr_fname: nul_trimmed(40, 16),
+        pr_psargs: nul_trimmed(56, 80),
+    })
+}
+
+/// ELF32 prpsinfo layout offsets (from <sys/procfs.h>):
+///
+/// ```text
+///   0: pr_state   (i8)
+///   1: pr_sname   (char)
+///   2: pr_zomb    (i8)
+///   3: pr_nice    (i8)
+///   4: pr_flag    (u32)
+///   8: pr_uid     (u16)  -- kernel uses u16 for 32-bit
+///  10: pr_gid     (u16)
+///  12: pr_pid     (i32)
+///  16: pr_ppid    (i32)
+///  20: pr_pgrp    (i32)
+///  24: pr_sid     (i32)
+///  28: pr_fname   ([u8; 16])
+///  44: pr_psargs  ([u8; 80])
+/// Total: 124 bytes
+/// ```
+fn parse_prpsinfo32(desc: &[u8], endian: ByteOrder) -> Option<Prpsinfo> {
+    if desc.len() < 124 {
+        return None;
+    }
+    let rd16 = |off: usize| endian.u16(desc[off..][..2].try_into().unwrap());
+    let rd32 = |off: usize| endian.u32(desc[off..][..4].try_into().unwrap());
+
+    let nul_trimmed = |start: usize, len: usize| -> String {
+        let slice = &desc[start..start + len];
+        let end = slice.iter().position(|&b| b == 0).unwrap_or(len);
+        String::from_utf8_lossy(&slice[..end]).into_owned()
+    };
+
+    Some(Prpsinfo {
+        pr_sname: desc[1] as char,
+        pr_nice: desc[3] as i8,
+        pr_uid: rd16(8) as u32,
+        pr_gid: rd16(10) as u32,
+        pr_pid: rd32(12),
+        pr_ppid: rd32(16),
+        pr_pgrp: rd32(20),
+        pr_sid: rd32(24),
+        pr_fname: nul_trimmed(28, 16),
+        pr_psargs: nul_trimmed(44, 80),
+    })
+}
+
+const NT_PRSTATUS: u32 = 1;
+const NT_PRPSINFO: u32 = 3;
+const NT_AUXV: u32 = 6;
+const ELFCLASS32: c_int = 1;
+const ELFCLASS64: c_int = 2;
+const EI_DATA: usize = 5;
+const ELFDATA2MSB: u8 = 2;
+
+impl CoreElf {
+    /// Return the word size (4 or 8) from the ELF class.
+    pub(super) fn word_size(&self) -> Option<usize> {
+        match unsafe { crate::dw_sys::gelf_getclass(self.elf.0) } {
+            ELFCLASS32 => Some(4),
+            ELFCLASS64 => Some(8),
+            _ => None,
+        }
+    }
+
+    /// Return the byte order from the ELF header.
+    pub(super) fn byte_order(&self) -> Option<ByteOrder> {
+        unsafe {
+            let mut ehdr = std::mem::zeroed::<crate::dw_sys::GElf_Ehdr>();
+            if crate::dw_sys::gelf_getehdr(self.elf.0, &mut ehdr).is_null() {
+                return None;
+            }
+            Some(if ehdr.e_ident[EI_DATA] == ELFDATA2MSB {
+                ByteOrder::Big
+            } else {
+                ByteOrder::Little
+            })
+        }
+    }
+
+    /// Parse all NT_PRSTATUS, NT_PRPSINFO, and NT_AUXV notes from the core file.
+    ///
+    /// Returns a map of TID -> Prstatus, an optional Prpsinfo (first one found),
+    /// and optional raw auxv bytes (first NT_AUXV note found).
+    pub(super) fn parse_notes(
+        &self,
+    ) -> (HashMap<u64, Prstatus>, Option<Prpsinfo>, Option<Vec<u8>>) {
+        let mut map = HashMap::new();
+        let mut prpsinfo = None;
+        let mut auxv_bytes: Option<Vec<u8>> = None;
+
+        let is_64 = match self.word_size() {
+            Some(8) => true,
+            Some(4) => false,
+            _ => return (map, prpsinfo, auxv_bytes),
+        };
+
+        let endian = match self.byte_order() {
+            Some(b) => b,
+            None => return (map, prpsinfo, auxv_bytes),
+        };
+
+        unsafe {
+            let mut phnum: libc::size_t = 0;
+            if crate::dw_sys::elf_getphdrnum(self.elf.0, &mut phnum) != 0 {
+                return (map, prpsinfo, auxv_bytes);
+            }
+
+            for i in 0..phnum as c_int {
+                let mut phdr = std::mem::zeroed::<crate::dw_sys::GElf_Phdr>();
+                if crate::dw_sys::gelf_getphdr(self.elf.0, i, &mut phdr).is_null() {
+                    continue;
+                }
+                if phdr.p_type != libc::PT_NOTE {
+                    continue;
+                }
+
+                // Get the raw data for this PT_NOTE segment.
+                let data = crate::dw_sys::elf_getdata_rawchunk(
+                    self.elf.0,
+                    phdr.p_offset as i64,
+                    phdr.p_filesz as libc::size_t,
+                    crate::dw_sys::ELF_T_NHDR,
+                );
+                if data.is_null() {
+                    continue;
+                }
+                let data_ref = &*data;
+                if data_ref.d_buf.is_null() || data_ref.d_size == 0 {
+                    continue;
+                }
+
+                let buf = std::slice::from_raw_parts(data_ref.d_buf as *const u8, data_ref.d_size);
+
+                // Iterate notes within this segment.
+                let mut offset: libc::size_t = 0;
+                loop {
+                    let mut nhdr = std::mem::zeroed::<crate::dw_sys::GElf_Nhdr>();
+                    let mut name_offset: libc::size_t = 0;
+                    let mut desc_offset: libc::size_t = 0;
+
+                    let next = crate::dw_sys::gelf_getnote(
+                        data as *mut _,
+                        offset,
+                        &mut nhdr,
+                        &mut name_offset,
+                        &mut desc_offset,
+                    );
+                    if next == 0 {
+                        break;
+                    }
+
+                    // Verify name starts with "CORE".  The ELF spec says
+                    // n_namesz includes the NUL terminator (so 5 for "CORE"),
+                    // but some producers set n_namesz == 4.
+                    let namesz = nhdr.n_namesz as usize;
+                    let name_ok = namesz >= 4
+                        && name_offset
+                            .checked_add(namesz)
+                            .is_some_and(|end| end <= buf.len())
+                        && buf[name_offset..name_offset + 4] == *b"CORE";
+
+                    if name_ok && desc_offset + nhdr.n_descsz as usize <= buf.len() {
+                        let desc = &buf[desc_offset..desc_offset + nhdr.n_descsz as usize];
+
+                        match nhdr.n_type {
+                            NT_PRSTATUS => {
+                                let parsed = if is_64 {
+                                    parse_prstatus64(desc, endian)
+                                } else {
+                                    parse_prstatus32(desc, endian)
+                                };
+                                if let Some(prstatus) = parsed {
+                                    map.insert(prstatus.pr_pid as u64, prstatus);
+                                }
+                            }
+                            NT_PRPSINFO if prpsinfo.is_none() => {
+                                prpsinfo = if is_64 {
+                                    parse_prpsinfo64(desc, endian)
+                                } else {
+                                    parse_prpsinfo32(desc, endian)
+                                };
+                            }
+                            NT_AUXV if auxv_bytes.is_none() => {
+                                auxv_bytes = Some(desc.to_vec());
+                            }
+                            _ => {}
+                        }
+                    }
+
+                    offset = next;
+                }
+            }
+        }
+
+        (map, prpsinfo, auxv_bytes)
     }
 }
 


### PR DESCRIPTION
Parse NT_PRSTATUS, NT_PRPSINFO, and NT_AUXV notes from the core file ELF headers (both 32-bit and 64-bit layouts) and use them as fallbacks in CoredumpSource when the corresponding systemd journal fields are unavailable. This enables extracting process stat, status, comm, cmdline, auxv, word size, and byte order directly from minimal core dumps that lack journal metadata.

Also add ByteOrder::u16/u32/u64 endian-aware conversion helpers and extract signal_bitmask_to_set for reuse from raw u64 signal masks.

Fixes #97
Fixes #98